### PR TITLE
use sqlite_backup instead of just directly copying db

### DIFF
--- a/browserexport/__main__.py
+++ b/browserexport/__main__.py
@@ -65,8 +65,8 @@ def save(browser: str, profile: str, to: str, path: Optional[str]) -> None:
         # hopefully this isn't needed a lot/can be replaced by
         # additional Browser+platform specific default paths
         _path_backup(path, to)
-        return
-    backup_history(browser, to, profile=profile)
+    else:
+        backup_history(browser, to, profile=profile)
 
 
 def _handle_merge(dbs: List[str], *, json: bool, stream: bool) -> None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 click
 logzero
 IPython
+sqlite_backup

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ reqs = Path("requirements.txt").read_text().strip().splitlines()
 pkg = "browserexport"
 setup(
     name=pkg,
-    version="0.1.3",
+    version="0.2.0",
     url="https://github.com/seanbreckenridge/browserexport",
     author="Sean Breckenridge",
     author_email="seanbrecke@gmail.com",


### PR DESCRIPTION
Is a tradeoff (a couple seconds slower)
but it has lots of advantages, see:
https://github.com/seanbreckenridge/sqlite_backup
