### PR TITLE
browsers: add Flatpak support for popular browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,11 +245,32 @@ The primary goals of promnesia and this are quite different -- this is tiny subs
 
 Eventually this project may be used in promnesia to replace the `browser.py` file
 
-### Testing
+## Contributing
+
+Clone the repository and create a virtual environment to do your work in.
 
 ```bash
 git clone https://github.com/seanbreckenridge/browserexport
 cd ./browserexport
+python -m venv .venv
+source .venv/bin/activate
+```
+
+### Development
+
+Install dependencies into your virtual environment and run the app as you normally would. Your machine should automatically use the version of the app in your virtual environment.
+
+```bash
+pip install .
+```
+
+As you make changes to the code, install them with the above command and test them out by running the app.
+
+For automated tests, see below.
+
+### Testing
+
+```bash
 pip install '.[testing]'
 pytest
 flake8 ./browserexport

--- a/browserexport/browsers/brave.py
+++ b/browserexport/browsers/brave.py
@@ -9,7 +9,10 @@ class Brave(Chrome):
     def data_directories(cls) -> Paths:
         return handle_path(
             {
-                "linux": "~/.config/BraveSoftware/Brave-Browser/",
+                "linux": (
+                    "~/.config/BraveSoftware/Brave-Browser/",
+                    "~/.var/app/com.brave.Browser/config/BraveSoftware/Brave-Browser/",
+                ),
                 "darwin": "~/Library/Application Support/BraveSoftware/Brave-Browser/",
             },
             browser_name=cls.__name__,

--- a/browserexport/browsers/chrome.py
+++ b/browserexport/browsers/chrome.py
@@ -54,7 +54,10 @@ class Chrome(Browser):
     def data_directories(cls) -> Paths:
         return handle_path(
             {
-                "linux": "~/.config/google-chrome/",
+                "linux": (
+                    "~/.config/google-chrome/",
+                    "~/.var/app/com.google.Chrome/config/google-chrome/",
+                ),
                 "darwin": "~/Library/Application Support/Google/Chrome/",
             },
             browser_name=cls.__name__,

--- a/browserexport/browsers/chromium.py
+++ b/browserexport/browsers/chromium.py
@@ -12,7 +12,11 @@ class Chromium(Chrome):
     def data_directories(cls) -> Paths:
         return handle_path(
             {
-                "linux": ("~/.config/chromium/", "~/snap/chromium/common/chromium/"),
+                "linux": (
+                    "~/.config/chromium/",
+                    "~/.var/app/org.chromium.Chromium/config/chromium/",
+                    "~/snap/chromium/common/chromium/",
+                ),
                 "darwin": "~/Library/Application Support/Chromium/",
             },
             browser_name=cls.__name__,

--- a/browserexport/browsers/common.py
+++ b/browserexport/browsers/common.py
@@ -106,7 +106,9 @@ def from_datetime_microseconds(ts: int) -> datetime:
     return datetime.fromtimestamp(ts / 1_000_000, tz=timezone.utc)
 
 
-errmsg = """Expected to match single database, got {}.
+errmsg = """Expected to match a single database, but found:
+{}
+
 You can use the --profile argument to select one of the profiles/match a particular file"""
 
 
@@ -117,7 +119,8 @@ def handle_glob(bases: Sequence[Path], stem: str, recursive: bool = False) -> Pa
     recur_desc = "recursive" if recursive else "non recursive"
     logger.debug(f"Glob {bases} with {stem} ({recur_desc}) matched {dbs}")
     if len(dbs) > 1:
-        raise RuntimeError(errmsg.format(dbs))
+        human_readable_db_paths: str = "\n".join([str(db) for db in dbs])
+        raise RuntimeError(errmsg.format(human_readable_db_paths))
     elif len(dbs) == 1:
         # found the match!
         return dbs[0]
@@ -182,6 +185,7 @@ def test_handle_path() -> None:
 
     expected_linux = (
         Path("~/.mozilla/firefox/").expanduser().absolute(),
+        Path("~/.var/app/org.mozilla.firefox/.mozilla/firefox/").expanduser().absolute(),
         Path("~/snap/firefox/common/.mozilla/firefox/").expanduser().absolute(),
     )
 

--- a/browserexport/browsers/firefox.py
+++ b/browserexport/browsers/firefox.py
@@ -53,6 +53,7 @@ class Firefox(Browser):
             {
                 "linux": (
                     "~/.mozilla/firefox/",
+                    "~/.var/app/org.mozilla.firefox/.mozilla/firefox/",
                     "~/snap/firefox/common/.mozilla/firefox/",
                 ),
                 "darwin": "~/Library/Application Support/Firefox/Profiles/",


### PR DESCRIPTION
This commit adds support for scanning Flatpak installations of:

- Brave Browser
- Google Chrome
- Chromium
- Firefox

The README has also been updated to add some instructions to help first-time developers get started with the project.